### PR TITLE
Initialize FastAPI backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Open Shelf
+
+This project provides a minimal full-stack application skeleton. The Python back end uses [FastAPI](https://fastapi.tiangolo.com/) and SQLAlchemy. A React front end lives in `client/` but is not yet implemented.
+
+## Development Setup
+
+1. **Install dependencies**
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. **Run the server**
+
+   ```bash
+   uvicorn server.main:app --reload
+   ```
+
+   The API will be available at `http://localhost:8000/`.
+
+### Configuration
+
+Environment variables can be placed in a `.env` file at the project root. The main setting is `DATABASE_URL`, which defaults to a local SQLite database (`sqlite:///./dev.db`).
+
+### Running tests
+
+```bash
+PYTHONPATH=. pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ psycopg2-binary
 sqlalchemy
 pydantic
 python-multipart
+httpx==0.24.1

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,0 +1,1 @@
+"Server package initialization"

--- a/server/config.py
+++ b/server/config.py
@@ -1,0 +1,10 @@
+from pydantic import BaseSettings
+
+class Settings(BaseSettings):
+    """Application configuration."""
+
+    app_name: str = "Open Shelf API"
+    debug: bool = False
+    database_url: str = "sqlite:///./dev.db"
+
+settings = Settings()

--- a/server/database.py
+++ b/server/database.py
@@ -1,0 +1,21 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+from .config import settings
+
+engine = create_engine(
+    settings.database_url,
+    connect_args={"check_same_thread": False} if settings.database_url.startswith("sqlite") else {},
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,14 @@
+from fastapi import FastAPI
+
+from .config import settings
+from .database import Base, engine
+
+# Create tables if they don't exist
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title=settings.app_name, debug=settings.debug)
+
+
+@app.get("/")
+async def root():
+    return {"message": "Welcome to the Open Shelf API"}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+
+from server.main import app
+
+client = TestClient(app)
+
+def test_root():
+    response = client.get('/')
+    assert response.status_code == 200
+    assert response.json() == {"message": "Welcome to the Open Shelf API"}


### PR DESCRIPTION
## Summary
- implement basic FastAPI server
- add SQLAlchemy database helpers
- pin httpx version
- document setup and tests
- add simple API test

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68472b2409c48322ab808aa61f714dd8